### PR TITLE
fix: Resending error message

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,6 +35,10 @@ func parseArgs(w io.Writer, args []string) (config, error) {
 		return c, err
 	}
 
+	if fs.NArg() != 0 {
+		return c, errPosArgSpecified
+	}
+
 	return c, nil
 }
 
@@ -87,10 +91,14 @@ func createTemplate(c config, name string) {
 	tmpl.Execute(file, name)
 }
 
+var errPosArgSpecified = errors.New("Positional arguments specified")
+
 func main() {
 	c, err := parseArgs(os.Stdout, os.Args[1:])
 	if err != nil {
-		fmt.Fprintln(os.Stdout, err)
+		if errors.Is(err, errPosArgSpecified) {
+			fmt.Fprintln(os.Stdout, err)
+		}
 		os.Exit(1)
 	}
 	err = validateArgs(c)

--- a/main_test.go
+++ b/main_test.go
@@ -28,17 +28,17 @@ func TestMain(t *testing.T) {
 		},
 		{
 			arg:      []string{"-h", ""},
-			output:   "Usage of greeter:\n  -n int\n    \tNumber of times to greet\n  -o string\n    \tFolder path for your HTML file\nflag: help requested\n",
+			output:   "Usage of greeter:\n  -n int\n    \tNumber of times to greet\n  -o string\n    \tFolder path for your HTML file\n",
 			exitCode: 1,
 		},
 		{
 			arg:      []string{"--help", ""},
-			output:   "Usage of greeter:\n  -n int\n    \tNumber of times to greet\n  -o string\n    \tFolder path for your HTML file\nflag: help requested\n",
+			output:   "Usage of greeter:\n  -n int\n    \tNumber of times to greet\n  -o string\n    \tFolder path for your HTML file\n",
 			exitCode: 1,
 		},
 		{
 			arg:      []string{"-h", "-n"},
-			output:   "Usage of greeter:\n  -n int\n    \tNumber of times to greet\n  -o string\n    \tFolder path for your HTML file\nflag: help requested\n",
+			output:   "Usage of greeter:\n  -n int\n    \tNumber of times to greet\n  -o string\n    \tFolder path for your HTML file\n",
 			exitCode: 1,
 		},
 	}


### PR DESCRIPTION
Fix resending error when user send in console not a nuber in arg.
Example:

```bash
> ./console-prog -n dwd
invalid value "dwd" for flag -n: parse error
Usage of greeter:
  -n int
        Number of times to greet
  -o string
        Folder path for your HTML file
invalid value "dwd" for flag -n: parse error
```

task 5