### PR TITLE
feature: Refactor parseArgs and main_test

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,13 @@ Run your app:
 
 If you run app with flag `-h` or `--help`:
 ```bash
-Usage of greeter:
-  -n int                                                           Number of times to greet
+A greeter application whitch prints the name you entered a specified number of times.
+
+Usage of greeter: <option> [name]
+
+Options: 
+  -n int
+        Number of times to greet
   -o string
         Folder path for your HTML file
 ```
@@ -30,16 +35,7 @@ Usage of greeter:
 
 Flag `-n` can write on console "Nice to meet you `<user_name>`. Example:
 ```bash
-➜  manual_parse git:(main) ✗ ./main -n 10
-Your name please? Press the Enter key when done.
-Richard
-Nite to meet you Richard
-Nite to meet you Richard
-Nite to meet you Richard
-Nite to meet you Richard
-Nite to meet you Richard
-Nite to meet you Richard
-Nite to meet you Richard
+> ./console-prog -n 3 "Richard"
 Nite to meet you Richard
 Nite to meet you Richard
 Nite to meet you Richard

--- a/main_test.go
+++ b/main_test.go
@@ -22,23 +22,33 @@ func TestMain(t *testing.T) {
 			exitCode: 0,
 		},
 		{
+			arg:      []string{"-n", "5", "Richard"},
+			output:   strings.Repeat("Nite to meet you Richard\n", 5),
+			exitCode: 0,
+		},
+		{
+			arg:      []string{"-n", "abc", "Richard"},
+			output:   "invalid value \"abc\" for flag -n: parse error\n\nA greeter application whitch prints the name you entered a specified number of times.\n\nUsage of greeter: <option> [name]\n\nOptions: \n  -n int\n    \tNumber of times to greet\n  -o string\n    \tFolder path for your HTML file\n",
+			exitCode: 1,
+		},
+		{
 			arg:      []string{"-n", "-5"},
 			output:   "Must specify a number greater than 0\n",
 			exitCode: 1,
 		},
 		{
 			arg:      []string{"-h", ""},
-			output:   "Usage of greeter:\n  -n int\n    \tNumber of times to greet\n  -o string\n    \tFolder path for your HTML file\n",
+			output:   "\nA greeter application whitch prints the name you entered a specified number of times.\n\nUsage of greeter: <option> [name]\n\nOptions: \n  -n int\n    \tNumber of times to greet\n  -o string\n    \tFolder path for your HTML file\n",
 			exitCode: 1,
 		},
 		{
 			arg:      []string{"--help", ""},
-			output:   "Usage of greeter:\n  -n int\n    \tNumber of times to greet\n  -o string\n    \tFolder path for your HTML file\n",
+			output:   "\nA greeter application whitch prints the name you entered a specified number of times.\n\nUsage of greeter: <option> [name]\n\nOptions: \n  -n int\n    \tNumber of times to greet\n  -o string\n    \tFolder path for your HTML file\n",
 			exitCode: 1,
 		},
 		{
 			arg:      []string{"-h", "-n"},
-			output:   "Usage of greeter:\n  -n int\n    \tNumber of times to greet\n  -o string\n    \tFolder path for your HTML file\n",
+			output:   "\nA greeter application whitch prints the name you entered a specified number of times.\n\nUsage of greeter: <option> [name]\n\nOptions: \n  -n int\n    \tNumber of times to greet\n  -o string\n    \tFolder path for your HTML file\n",
 			exitCode: 1,
 		},
 	}


### PR DESCRIPTION
A new processing of the additional username argument has been added, and the README has also been updated.

Before:
```bash
➜  manual_parse git:(main) ✗ ./main -n 10
Your name please? Press the Enter key when done.
Richard
Nite to meet you Richard
Nite to meet you Richard
...
```

After:
```bash
> ./console-prog -n 3 "Richard"
Nite to meet you Richard
Nite to meet you Richard
Nite to meet you Richard
```

task 5